### PR TITLE
Add support for usbreset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,8 @@ RUN set -x && \
     KEPT_PACKAGES+=(libfftw3-3) && \
     TEMP_PACKAGES+=(libfftw3-dev) && \
     TEMP_PACKAGES+=(libusb-1.0-0-dev) && \
+    # Packages for usbreset
+    KEPT_PACKAGES+=(usbutils) && \
     # Install packages.
     apt-get update && \
     apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y --no-install-recommends \

--- a/rootfs/etc/cont-init.d/06-rtlsdr-usbreset
+++ b/rootfs/etc/cont-init.d/06-rtlsdr-usbreset
@@ -1,0 +1,4 @@
+#!/usr/bin/execlineb -P
+background {
+  /scripts/usbreset.sh
+}

--- a/rootfs/scripts/usbreset.sh
+++ b/rootfs/scripts/usbreset.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/with-contenv bash
+# shellcheck shell=bash
+
+if [[ "$READSB_DEVICE_TYPE" == "rtlsdr" ]]; then
+    if [[ -n "$READSB_USBRESET" ]]; then
+      sleep 30
+      USBNAME=RTL2838
+      LSUSB=$(lsusb | grep --ignore-case $USBNAME)
+      DEVICE=$(echo $LSUSB | cut --delimiter=' ' --fields='2')"/"$(echo $LSUSB | cut --delimiter=' ' --fields='4' | tr --delete ":")
+      usbreset $DEVICE
+    fi
+fi

--- a/rootfs/scripts/usbreset.sh
+++ b/rootfs/scripts/usbreset.sh
@@ -6,7 +6,7 @@ if [[ "$READSB_DEVICE_TYPE" == "rtlsdr" ]]; then
       sleep 30
       USBNAME=RTL2838
       LSUSB=$(lsusb | grep --ignore-case $USBNAME)
-      DEVICE=$(echo $LSUSB | cut --delimiter=' ' --fields='2')"/"$(echo $LSUSB | cut --delimiter=' ' --fields='4' | tr --delete ":")
-      usbreset $DEVICE
+      DEVICE=$(echo "$LSUSB" | cut --delimiter=' ' --fields='2')"/"$(echo "$LSUSB" | cut --delimiter=' ' --fields='4' | tr --delete ":")
+      usbreset "$DEVICE"
     fi
 fi


### PR DESCRIPTION
Adds support for running usbreset on the RTL-SDR dongle after readsb starts. Environment variable `READSB_USBRESET` needs to be defined for it to work.

It should work on all platforms as it uses the `usbutils` package, I have not tested with multiple RTL-SDR dongles.