### PR TITLE
Fix autogain service script if disabled

### DIFF
--- a/rootfs/etc/services.d/autogain/run
+++ b/rootfs/etc/services.d/autogain/run
@@ -1,22 +1,16 @@
 #!/usr/bin/with-contenv bash
 #shellcheck shell=bash
 
-# If gain is specified...
-if [[ -n "$READSB_GAIN" ]]; then
+# If gain is specified and user wants to use the autogain system...
+if [[ -n "$READSB_GAIN" ]] && [[ "$READSB_GAIN" == "autogain" ]]; then
+    set -eo pipefail
 
-    # If the user wants to use the autogain system...
-    if [[ "$READSB_GAIN" == "autogain" ]]; then
+    # Run autogain
+    #shellcheck disable=SC2016
+    bash /scripts/autogain.sh 2>&1 | stdbuf -o0 awk '{print "[autogain] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
 
-        set -eo pipefail
-
-        # Run autogain
-        #shellcheck disable=SC2016
-        bash /scripts/autogain.sh 2>&1 | stdbuf -o0 awk '{print "[autogain] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
-
-        # Sleep for 15 mins
-        sleep "$AUTOGAIN_SERVICE_PERIOD"
-
-    fi
+    # Sleep for 15 mins
+    sleep "$AUTOGAIN_SERVICE_PERIOD"
 
 else
     sleep 86400


### PR DESCRIPTION
Small update to `autogain/run` to an avoid a continues restart loop caused by `s6-supervise autogain`.
This was causing a lot of i/o on my raspberry pi micro sd card. This happend with env var `READSB_GAIN=40`.