### PR TITLE
Include aggressive and preamble threshold options

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Where the default value is "Unset", `readsb`'s default will be used.
 
 | Variable | Description | Controls which `readsb` option | Default |
 |----------|-------------|--------------------------------|---------|
+| `READSB_AGGRESSIVE` | Set to any value to enable two-bit CRC error correction | `--aggressive` | Unset |
 | `READSB_DCFILTER` | Set to any value to apply a 1Hz DC filter to input data (requires more CPU) | `--dcfilter` | Unset |
 | `READSB_DEVICE_TYPE` | If using an SDR, set this to `rtlsdr`, `bladerf`, `modesbeast`, `gnshulc` or `plutosdr` depending on the model of your SDR. If not using an SDR, leave un-set. | `--device-type=<type>` | Unset |
 | `READSB_ENABLE_BIASTEE` | Set to any value to enable bias tee on supporting interfaces | `--enable-biastee` | Unset |
@@ -321,6 +322,7 @@ Where the default value is "Unset", `readsb`'s default will be used.
 | `READSB_NO_CRC_CHECK` | Set this to any value to disable messages with invalid CRC (discouraged) | `--no-crc-check` | Unset |
 | `READSB_NO_FIX` | Set this to any value to disable CRC single-bit error correction | `--no-fix` | Unset |
 | `READSB_NO_MODEAC_AUTO` | Set this to any value and Mode A/C won't be enabled automatically if requested by a Beast connection | `--no-modeac-auto` | Unset |
+| `READSB_PREAMBLE_THRESHOLD` | Preamble threshold, lower means more CPU usage (valid range: `40` - `400`) | `--preamble-threshold=<n>` | `58` |
 | `READSB_RX_LOCATION_ACCURACY` | Accuracy of receiver location in metadata: `0`=no location, `1`=approximate, `2`=exact | `--rx-location-accuracy=<n>` | Unset |
 | `READSB_STATS_EVERY` | Number of seconds between showing and resetting stats. | `--stats-every=<sec>` | Unset |
 | `READSB_STATS_RANGE` | Set this to any value to collect range statistics for polar plot. | `--stats-range` |  Unset |

--- a/rootfs/etc/services.d/readsb/run
+++ b/rootfs/etc/services.d/readsb/run
@@ -22,6 +22,11 @@ READSB_CMD+=("--write-output=/run/readsb")
 
 ##### GENERAL OPTIONS #####
 
+# Handle "--aggressive"
+if [[ -n "$READSB_AGGRESSIVE" ]]; then
+    READSB_CMD+=("--aggressive")
+fi
+
 # Handle "--dcfilter"
 if [[ -n "$READSB_DCFILTER" ]]; then
     READSB_CMD+=("--dcfilter")
@@ -114,6 +119,11 @@ fi
 # Handle "--no-modeac-auto"
 if [[ -n "$READSB_NO_MODEAC_AUTO" ]]; then
     READSB_CMD+=("--no-modeac-auto")
+fi
+
+# Handle "--preamble-threshold=<n>"
+if [[ -n "$READSB_PREAMBLE_THRESHOLD" ]]; then
+    READSB_CMD+=("--preamble-threshold=$READSB_PREAMBLE_THRESHOLD")
 fi
 
 # Handle "--rx-location-accuracy=<n>"


### PR DESCRIPTION
This PR includes support for the `--aggressive` option and `--preamble-threshold` option. These options have existed in the underlying readsb implementation but have not been exposed via the run script.